### PR TITLE
Remove toolsDependencies items

### DIFF
--- a/package_MCUdude_MegaCore_index.json
+++ b/package_MCUdude_MegaCore_index.json
@@ -25,18 +25,7 @@
             {"name": "ATmega128"},
             {"name": "ATmega64"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         },
         {
           "name": "MegaCore",
@@ -54,18 +43,7 @@
             {"name": "ATmega128"},
             {"name": "ATmega64"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         },
         {
           "name": "MegaCore",
@@ -83,18 +61,7 @@
             {"name": "ATmega128"},
             {"name": "ATmega64"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         },
         {
           "name": "MegaCore",
@@ -112,18 +79,7 @@
             {"name": "ATmega128"},
             {"name": "ATmega64"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         }
       ],
       "tools": []


### PR DESCRIPTION
Previously, installing MegaCore in Arduino IDE 1.6.10 caused the
installation of avr-gcc 4.8.1-arduino5. This forced Arduino AVR Boards
1.6.12 to use that avr-gcc version, which it is incompatible with,
causing compiling any Arduino AVR Board to fail.

Now that no tools dependencies are listed, MegaCore will use whatever
version of these tools is currently installed in the Arduino IDE(avr-gcc
4.8.1-arduino5 in Arduino IDE 1.6.9 and previous, avr-gcc
4.9.2-atmel3.5.3-arduino2 in Arduino IDE 1.6.10).

Boards Manager URL for testing:
https://raw.githubusercontent.com/per1234/MegaCore/remove-tools-dependencies/package_MCUdude_MegaCore_index.json