### PR TITLE
Fix header Markdown in Wiring Reference

### DIFF
--- a/Wiring_reference.md
+++ b/Wiring_reference.md
@@ -1,7 +1,7 @@
-#Wiring reference
+# Wiring reference
 To extend this core's functionality a bit futher, I've added a few missing Wiring functions. As many of you know Arduino is based on Wiring, but that doesn't mean the Wiring development isnt active. These functions is used as "regular" Arduino functions, and there's no need to include an external library.
 
-##Content
+## Content
 * [portMode](#portmode)()
 * [portRead](#portread)()
 * [portWrite](#portwrite)()
@@ -11,15 +11,15 @@ To extend this core's functionality a bit futher, I've added a few missing Wirin
 * [enablePower](#enablepower)()	
 * [disablepower](#disablePower)()
 
-##portMode()
+## portMode()
 The <b>portMode()</b> method sets a specified digital I/O port as INPUT or OUTPUT. A digital I/O port is a group of 8 pins. By writing 0 to a port it will set individually each of the 8 pins to 0 (LOW). Possible values range from 0 to 255. It possible to read or write a value of a digital I/O port by using the <b>[portRead()](#portread)</b> and <b>[portWrite()](#portwrite)</b> methods.
 
-###Syntax
+### Syntax
 ``` c++
 portMode(portNumber, value)
 ```
 
-####Parameters
+#### Parameters
 `portNumber` - <i>byte/uint8_t</i> <br/>
 `value` - <i>byte/uint8_t</i>
 
@@ -30,11 +30,11 @@ portMode(portNumber, value)
 | 2           | PORTC         |
 | 3           | PORTD         |
 
-####Returns
+#### Returns
 `none`
 <br/>
 
-###Example
+### Example
 ``` c++
 byte portNumber = 1; // Use port B
 byte val = 0;
@@ -53,15 +53,15 @@ void loop() {
 
 
 
-##portRead()
+## portRead()
 The <b>portRead()</b> method reads the value of the digital input port specified.
 
-###Syntax
+### Syntax
 ``` c++
 portRead(portNumber)
 ```
 
-####Parameters
+#### Parameters
 `portNumber` - <i>byte/uint8_t</i> <br/>
 
 | PortNumber  | Physical port |
@@ -71,11 +71,11 @@ portRead(portNumber)
 | 2           | PORTC         |
 | 3           | PORTD         |
 
-####Returns
+#### Returns
 `byte/uint8_t`
 <br/>
 
-###Example
+### Example
 ``` c++
 byte inport = 1;
 byte val = 0;
@@ -93,15 +93,15 @@ void loop() {
 
 
 
-##portWrite()
+## portWrite()
 The <b>portWrite()</b> method writes a value to the digital output port specified.
 
-###Syntax
+### Syntax
 ``` c++
 portWrite(portNumber, value)
 ```
 
-####Parameters
+#### Parameters
 `portNumber` - <i>byte/uint8_t</i> <br/>
 `value` - <i>byte/uint8_t</i>
 
@@ -112,11 +112,11 @@ portWrite(portNumber, value)
 | 2           | PORTC         |
 | 3           | PORTD         |
 
-####Returns
+#### Returns
 `none`
 <br/>
 
-###Example
+### Example
 ``` c++
 byte outport = 1;
 byte val = 0;
@@ -135,7 +135,7 @@ void loop() {
 
 
 
-##sleepMode()
+## sleepMode()
 Sleep modes enable the application to shut down unused modules in the microcontroller, thereby saving power. The default mode is SLEEP_IDLE. Different AVR devices provides various sleep modes allowing the user to tailor the power consumption to the application's requirements. There are six sleep modes set by the sleepMode() command. <br/>
 <b>SLEEP_IDLE:</b> makes the MCU enter Idle mode, stopping the CPU but allowing the SPI, Serial, Analog Comparator, ADC, Wire, Timer/Counters and the interrupt system to continue operating. This mode enables the microcontroller to wake up from external triggered interrupts as well as internal ones like the Timer Overflow and Serial Transmit Complete interrupts.
 SLEEP_ADC: makes the microcontroller enter ADC Noise Reduction mode, stopping the CPU but allowing the ADC, the external interrupts, Wire Serial Interface address match and Timer/Counter2. This improves the noise environment for the ADC, enabling higher resolution measurements. If the ADC is enabled, a conversion starts automatically when this mode is entered. Only an External Reset, a Wire serial interface interrupt, a Timer/Counter2 interrupt, an SPM/EEPROM ready interrupt, an external level interrupt on INT7:4 or a pin change interrupt can wakeup the microcontroller from ADC Noise Reduction mode.<br/>
@@ -144,12 +144,12 @@ SLEEP_ADC: makes the microcontroller enter ADC Noise Reduction mode, stopping th
 <b>SLEEP_STANDBY:</b> This mode is identical to SLEEP_POWER_SAVE mode with the exception that the Oscillator is kept running.<br/>
 <b>SLEEP_EXTENDED_STANDBY:</b> This mode is identical to SLEEP_POWER_SAVE mode with the exception that the Oscillator is kept running. From SLEEP_EXTENDED_STANDBY mode, the device wakes up in six clock cycles.<br/>
 
-###Syntax
+### Syntax
 ``` c++
 sleepMode(mode)
 ```
 
-####Parameters
+#### Parameters
 `mode` - <i>byte/uint8_t</i> <br/>
 
 | mode                   |
@@ -161,11 +161,11 @@ sleepMode(mode)
 | SLEEP_STANDBY          |
 | SLEEP_EXTENDED_STANDBY |
 
-####Returns
+#### Returns
 `none`
 <br/>
 
-###Example
+### Example
 ``` c++
 // ...
 
@@ -180,18 +180,18 @@ if(some_condition)
 // ...
 ```
 
-##sleep()
+## sleep()
 the <b>sleep()</b> command can allow an application to reduce its power comsumption considerably. Sleep modes enable the application to shut down unused modules in the microcontroller, thereby saving power. The default mode is SLEEP_IDLE. Different AVR devices provides various sleep modes allowing the user to tailor the power consumption to the application's requirements. There are six sleep modes set by the [sleepMode()](#sleepmode) command.
 
-###Syntax
+### Syntax
 ``` c++
 sleep()
 ```
 
-####Returns
+#### Returns
 `none`
 
-###Example
+### Example
 ``` c++
 // ...
 
@@ -208,18 +208,18 @@ if(some_condition)
 
 
 
-##noSleep()
+## noSleep()
 the <b>noSleep()</b> command wakes up the microcontroller from a previous [sleep()](#sleep). Sleep modes enable the application to shut down unused modules in the microcontroller, thereby saving power. The default mode is SLEEP_IDLE. Different AVR devices provides various sleep modes allowing the user to tailor the power consumption to the application's requirements. There are six sleep modes set by the [sleepMode()](#sleepmode) command.
 
-###Syntax
+### Syntax
 ``` c++
 noSleep()
 ```
 
-####Returns
+#### Returns
 `none`
 
-###Example
+### Example
 ``` c++
 // ...
 


### PR DESCRIPTION
GitHub's Markdown interpreter was recently changed to strictly enforce the [GFM spec](https://github.github.com/gfm/), which requires a delimiting space in header Markdown. This has caused some Markdown to no longer display as originally intended.

More information:
https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown
https://github.com/github/markup/issues/1013