### PR TITLE
Add leading zeros to the report folder name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -411,7 +411,7 @@ after_script:
   - USER_NAME="$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f 1)"
   - REPOSITORY_NAME="$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f 2)"
   # Commit a report of the job results to a folder named with the build number in the MegaCore branch of the Travis-build-outputs repository
-  - publish_report_to_repository "$REPORT_GITHUB_TOKEN" "https://github.com/${USER_NAME}/CI-reports.git" "$REPOSITORY_NAME" "build_${TRAVIS_BUILD_NUMBER}" "false"
+  - publish_report_to_repository "$REPORT_GITHUB_TOKEN" "https://github.com/${USER_NAME}/CI-reports.git" "$REPOSITORY_NAME" "build_$(printf "%05d\n" "${TRAVIS_BUILD_NUMBER}")" "false"
 
   # Print a tab separated report of all sketch verification results to the log
   - display_report


### PR DESCRIPTION
Without the leading zeros the folder listing in the report repository is not shown in the correct order:
![clipboard01](https://cloud.githubusercontent.com/assets/8572152/26277770/72f83438-3d43-11e7-88b2-0f852ffe4044.png)
