### PR TITLE
Turn on library testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -394,6 +394,9 @@ before_install:
   # Check for board definition errors that don't affect compilation
   - set_board_testing "true"
 
+  # Check for library issues that don't affect compilation
+  - set_library_testing "true"
+
   # Install all IDE version required by the job
   - install_ide "$START_IDE_VERSION" "$END_IDE_VERSION"
 


### PR DESCRIPTION
This will cause the build to fail if a library issue is detected. Library issues are problems that cause the Arduino IDE to display a warning, rather than the compiler. Examples are:
- Invalid category in library.properties
- Missing maintainer, etc. in library.properties
- Spurious .folder in library folder
- Invalid library in libraries folder

It's up to you whether you want to turn this on. Some of these warnings, such as invalid category, don't indicate an issue that could have any effect on compilation. However, I've seen over and over on the forum that these warnings cause undue alarm in users and often mislead them from the true cause of the problem they're having.

Note that the script always detects and includes a count of library issues in the report, this setting only determines whether a library issue will cause the build to fail.