### PR TITLE
Give libraries unique name values in library.properties

### DIFF
--- a/avr/libraries/Ethernet/library.properties
+++ b/avr/libraries/Ethernet/library.properties
@@ -1,4 +1,4 @@
-name=Ethernet
+name=Ethernet (MegaCore)
 version=1.1.1
 author=Arduino
 maintainer=MCUdude

--- a/avr/libraries/SD/library.properties
+++ b/avr/libraries/SD/library.properties
@@ -1,4 +1,4 @@
-name=SD
+name=SD (MegaCore)
 version=1.0.7
 author=Arduino, SparkFun
 maintainer=Arduino <info@arduino.cc>

--- a/avr/libraries/Servo/library.properties
+++ b/avr/libraries/Servo/library.properties
@@ -1,4 +1,4 @@
-name=Servo
+name=Servo (MegaCore)
 version=1.1.1
 author=Michael Margolis, Arduino
 maintainer=MCUdude


### PR DESCRIPTION
Library Manager has a problem where libraries are shown as always updatable if the hardware package of the selected board contains a library with the same `name` value in library.properties as a library bundled with the Arduino IDE and there is a newer version of the library available that the version of the library in the hardware package. This issue currently occurs for MegaCore boards with the SD library and with Ethernet and Servo libraries in Arduino IDE ca 1.6.8. The backwards compatible workaround is to give the libraries unique `name` values in library.properties.