### PR TITLE
Fix upload.port property for 128 1 MHz

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -647,7 +647,7 @@ menu.pinout=Pinout
 128.menu.clock.8MHz_internal.build.f_cpu=8000000L
 
 128.menu.clock.1MHz_internal=1 MHz internal
-128.menu.clock.8MHz_internal.upload.port=UART0
+128.menu.clock.1MHz_internal.upload.port=UART0
 128.menu.clock.1MHz_internal.upload.speed=9600
 128.menu.clock.1MHz_internal.bootloader.sut_cksel_bits=100001
 128.menu.clock.1MHz_internal.bootloader.high_fuses=0xd6


### PR DESCRIPTION
Due to a typo, the `upload.port` property was not being defined for ATmega128 1 MHz internal board. This produced the warning:
```
Bootloader file specified but missing: E:\Stuff\misc\electronics\arduino\hardware\MegaCore-master\avr\bootloaders\optiboot_flash\atmega128\optiboot_flash_atmega128_{upload.port}_9600_1000000L.hex
```
on every compilation for this board. This warning caused the [Travis CI jobs](https://travis-ci.org/MCUdude/MegaCore/builds/328302760) for this board to fail due to the `set_board_testing` feature (which detects this sort of warning) being [enabled](https://github.com/MCUdude/MegaCore/blob/master/.travis.yml#L395). This would also cause the Burn Bootloader process to fail.

Fixes https://github.com/MCUdude/MegaCore/issues/80