### PR TITLE
 Add AT90CAN128/64/32 to Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,10 @@ env:
     # Arduino IDE 1.6.3-1.6.5-r5 on Linux don't seem to include the MegaCore bundled library files.
     # Arduino IDE 1.6.6 has many function prototype generation failures.'
     # So testing is done with Arduino IDE 1.6.7 and newer.
-    - OLDEST_IDE_VERSION_TO_TEST="1.6.7"
+    - FULL_IDE_VERSION_LIST='("1.6.7" "1.6.9" "1.6.13" "1.8.6" "newest")'
 
     # README.md states that LTO should only be used with Arduino IDE 1.6.11 and newer
-    - OLDEST_IDE_VERSION_TO_TEST_WITH_LTO="1.6.11"
-
-    # In order to keep some of the job durations under the maximum allowed by Travis CI I have to split the IDE range in two
-    - FIRST_SPLIT_JOB_START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST"
-    - FIRST_SPLIT_JOB_END_IDE_VERSION="1.6.13"
-    - SECOND_SPLIT_JOB_START_IDE_VERSION="1.8.0"
-    - SECOND_SPLIT_JOB_END_IDE_VERSION="newest"
+    - LTO_IDE_VERSION_LIST='("1.6.11" "1.6.13" "1.8.6" "newest")'
 
 
 matrix:
@@ -85,415 +79,384 @@ matrix:
     # Compile every example sketch for every library included with MegaCore for every MCU, every board option, every installed IDE version
     # Each line in the matrix will be run as a separate job in the Travis CI build
     # bootloader=uart0, pinout=avr_pinout, BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart0,pinout=avr_pinout,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart0,pinout=avr_pinout,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart0,pinout=avr_pinout,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=uart1, pinout=mega_pinout, BOD=4v3, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart1,pinout=mega_pinout,BOD=4v3,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart1,pinout=mega_pinout,BOD=4v3,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # bootloader=uart2, BOD=1v8, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart2,pinout=mega_pinout,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart2,pinout=mega_pinout,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart2,pinout=mega_pinout,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=uart3, BOD=disabled, clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart3,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart3,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart3,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=no_bootloader, clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=no_bootloader,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=no_bootloader,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=no_bootloader,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     # BOD=disabled, clock=8MHz_internal
-    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:2560:bootloader=uart0,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:2560:bootloader=uart0,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart0,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart0,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2560:bootloader=uart0,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # bootloader=uart0, pinout=avr_pinout, BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart0,pinout=avr_pinout,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart0,pinout=avr_pinout,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart0,pinout=avr_pinout,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=uart1, pinout=mega_pinout, BOD=4v3, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart1,pinout=mega_pinout,BOD=4v3,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart1,pinout=mega_pinout,BOD=4v3,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # bootloader=uart2, BOD=1v8, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart2,pinout=mega_pinout,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart2,pinout=mega_pinout,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart2,pinout=mega_pinout,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=uart3, BOD=disabled, clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart3,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart3,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart3,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=no_bootloader, clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=no_bootloader,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=no_bootloader,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=no_bootloader,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     # BOD=disabled, clock=8MHz_internal
-    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:1280:bootloader=uart0,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:1280:bootloader=uart0,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart0,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart0,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1280:bootloader=uart0,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # bootloader=uart0, pinout=avr_pinout, BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart0,pinout=avr_pinout,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart0,pinout=avr_pinout,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart0,pinout=avr_pinout,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=uart1, pinout=mega_pinout, BOD=4v3, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart1,pinout=mega_pinout,BOD=4v3,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart1,pinout=mega_pinout,BOD=4v3,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # bootloader=uart2, BOD=1v8, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart2,pinout=mega_pinout,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart2,pinout=mega_pinout,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart2,pinout=mega_pinout,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=uart3, BOD=disabled, clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart3,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart3,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart3,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=no_bootloader, clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=no_bootloader,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=no_bootloader,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=no_bootloader,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     # BOD=disabled, clock=8MHz_internal
-    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:640:bootloader=uart0,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:640:bootloader=uart0,pinout=mega_pinout,BOD=disabled,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart0,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart0,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:640:bootloader=uart0,pinout=mega_pinout,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # bootloader=uart0, BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=uart1, BOD=4v3, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart1,BOD=4v3,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart1,BOD=4v3,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # bootloader=no_bootloader, BOD=1v8, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=no_bootloader,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=no_bootloader,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=no_bootloader,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=disabled, clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # F_CPU of 8 MHz has already been fully tested and the internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     # clock=8MHz_internal
-    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:2561:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # bootloader=uart0, BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=uart1, BOD=4v3, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart1,BOD=4v3,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart1,BOD=4v3,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # bootloader=no_bootloader, BOD=1v8, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=no_bootloader,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=no_bootloader,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=no_bootloader,BOD=1v8,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=disabled, clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=disabled,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # F_CPU of 8 MHz has already been fully tested and the internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     # clock=8MHz_internal
-    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:1281:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # ATmega128 and ATmega64 are not supported by the SoftwareSerial library so each library must be specified to avoid the build failing from compiling the SoftwareSerial examples for these parts
     # bootloader=uart0, BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=uart1, BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=uart1,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=uart1,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # bootloader=no_bootloader, BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=no_bootloader,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=no_bootloader,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=no_bootloader,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=no_bootloader,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # F_CPU of 8 MHz has already been fully tested and the internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     # clock=8MHz_internal
-    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:128:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # bootloader=uart0, BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=uart1, BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=uart1,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=uart1,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # bootloader=no_bootloader, BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=no_bootloader,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=no_bootloader,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=no_bootloader,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=no_bootloader,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/AVR_examples" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/EEPROM" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Ethernet" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Optiboot_flasher" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SD" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Servo" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/SPI" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Timer" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v0, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=4v0,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # BOD=disabled, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=disabled,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries/Wire" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # F_CPU of 8 MHz has already been fully tested and the internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     # clock=8MHz_internal
-    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # bootloader=uart0, BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v1, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=4v1,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=4v1,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # bootloader=uart1, BOD=4v0, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=no_bootloader, BOD=3v9, clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=3v8, clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     # BOD=2v6, clock=8MHz_internal
-    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=2v6,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
-    # BOD=2v5/disabled, clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=2v5,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=disabled,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=2v6,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
+    # BOD=2v5, clock=1MHz_internal
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=2v5,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
+    # BOD configuration will have no effect on code so it's only necessary to do a single verification per IDE version for this job
+    # BOD=disabled
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=disabled,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # bootloader=uart0, BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v1, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=4v1,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=4v1,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # bootloader=uart1, BOD=4v0, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=no_bootloader, BOD=3v9, clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=3v8, clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     # BOD=2v6, clock=8MHz_internal
-    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=2v6,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
-    # BOD=2v5/disabled, clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=2v5,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=disabled,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=2v6,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
+    # BOD=2v5, clock=1MHz_internal
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=2v5,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
+    # BOD configuration will have no effect on code so it's only necessary to do a single verification per IDE version for this job
+    # BOD=disabled
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=disabled,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
     # bootloader=uart0, BOD=2v7, LTO=Os, clock=16MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=4v1, LTO=Os_flto, clock=20MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=4v1,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=4v1,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$LTO_IDE_VERSION_LIST"
     # bootloader=uart1, BOD=4v0, clock=18_432MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # bootloader=no_bootloader, BOD=3v9, clock=12MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # BOD=3v8, clock=8MHz_external
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
     # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
     # BOD=2v6, clock=8MHz_internal
-    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=2v6,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
-    # BOD=2v5/disabled, clock=1MHz_internal
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=2v5,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
-    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=disabled,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=2v6,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
+    # BOD=2v5, clock=1MHz_internal
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=2v5,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
+    # BOD configuration will have no effect on code so it's only necessary to do a single verification per IDE version for this job
+    # BOD=disabled
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=disabled,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" IDE_VERSION_LIST="$FULL_IDE_VERSION_LIST"
 
 
 # Shared phase definitions, which will be used for any job that doesn't define its own
@@ -520,7 +483,7 @@ before_install:
   - install_package
 
   # Install all IDE version required by the job
-  - install_ide "$START_IDE_VERSION" "$END_IDE_VERSION"
+  - install_ide "$IDE_VERSION_LIST"
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -432,6 +432,69 @@ matrix:
     # clock=8MHz_internal
     - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:64:bootloader=uart0,BOD=2v7,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
 
+    # bootloader=uart0, BOD=2v7, LTO=Os, clock=16MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # BOD=4v1, LTO=Os_flto, clock=20MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=4v1,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    # bootloader=uart1, BOD=4v0, clock=18_432MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # bootloader=no_bootloader, BOD=3v9, clock=12MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # BOD=3v8, clock=8MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
+    # BOD=2v6, clock=8MHz_internal
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=2v6,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    # BOD=2v5/disabled, clock=1MHz_internal
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=2v5,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can128:bootloader=uart0,BOD=disabled,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+
+    # bootloader=uart0, BOD=2v7, LTO=Os, clock=16MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # BOD=4v1, LTO=Os_flto, clock=20MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=4v1,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    # bootloader=uart1, BOD=4v0, clock=18_432MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # bootloader=no_bootloader, BOD=3v9, clock=12MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # BOD=3v8, clock=8MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
+    # BOD=2v6, clock=8MHz_internal
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=2v6,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    # BOD=2v5/disabled, clock=1MHz_internal
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=2v5,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can64:bootloader=uart0,BOD=disabled,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+
+    # bootloader=uart0, BOD=2v7, LTO=Os, clock=16MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=2v7,LTO=Os,clock=16MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # BOD=4v1, LTO=Os_flto, clock=20MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=4v1,LTO=Os_flto,clock=20MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO" END_IDE_VERSION="newest"
+    # bootloader=uart1, BOD=4v0, clock=18_432MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart1,BOD=4v0,LTO=Os,clock=18_432MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # bootloader=no_bootloader, BOD=3v9, clock=12MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=no_bootloader,BOD=3v9,LTO=Os,clock=12MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # BOD=3v8, clock=8MHz_external
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=3v8,LTO=Os,clock=8MHz_external" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+    # F_CPU of 8 MHz has already been fully tested and the BOD and internal clock configuration will have no effect on code so it's only necessary to do a single verification per IDE version for the 8 MHz internal clock setting
+    # BOD=2v6, clock=8MHz_internal
+    - env: SKETCH_PATH="${APPLICATION_FOLDER}/arduino/examples/01.Basics/BareMinimum/BareMinimum.ino" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=2v6,LTO=Os,clock=8MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$OLDEST_IDE_VERSION_TO_TEST" END_IDE_VERSION="newest"
+    # BOD=2v5/disabled, clock=1MHz_internal
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=2v5,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$FIRST_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$FIRST_SPLIT_JOB_END_IDE_VERSION"
+    - env: SKETCH_PATH="${SKETCHBOOK_FOLDER}/hardware/MegaCore/avr/libraries" BOARD_ID="MegaCore:avr:can32:bootloader=uart0,BOD=disabled,LTO=Os,clock=1MHz_internal" ALLOW_FAILURE="false" START_IDE_VERSION="$SECOND_SPLIT_JOB_START_IDE_VERSION" END_IDE_VERSION="$SECOND_SPLIT_JOB_END_IDE_VERSION"
+
 
 # Shared phase definitions, which will be used for any job that doesn't define its own
 before_install:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Select your microcontroller in the boards menu, then select the clock frequency.
 Make sure you connect an ISP programmer, and select the correct one in the "Programmers" menu. For time critical applications an external oscillator is recommended.
 </br></br>
 
-<b>*</b> There might be some issues related to the internal oscillator. It's factory calibrated, but may be a little "off" depending on the calibration, ambient temperature and operating voltage. If uploading failes while using the 8 MHz internal oscillator you have three options:
+<b>*</b> There might be some issues related to the internal oscillator. It's factory calibrated, but may be a little "off" depending on the calibration, ambient temperature and operating voltage. If uploading fails while using the 8 MHz internal oscillator you have three options:
 * Edit the baudrate line in the [boards.txt](https://github.com/MCUdude/MegaCore/blob/25ad60968abd59b3931e75e4d378f0878d2bf716/avr/boards.txt#L123) file, and choose either 115200, 57600, 38400, 19200 or 9600 baud.
 * Upload the code using a programmer (USBasp, USBtinyISP etc.) or skip the bootloader
 * Use the 1 MHz option instead
@@ -161,7 +161,7 @@ I hope you find this useful, because they really are!
 ## Pinout
 
 ### ATmega64/128/1281/2561/CAN32/CAN64/CAN128
-Since there are no standarized Arduino pinout for this chip family, I've created one. I've tried to make it as simple and logical as possible. This pinout makes great sense if you're buying this [cheap breakout boards](http://www.ebay.com/itm/381547311629) at Ebay or AliExpress (just make sure to remove C3 in order to get auto reset working). The standard LED pin is assigned to Arduino pin 13, and will blink twice if you hit the reset button.
+Since there are no standardized Arduino pinout for this chip family, I've created one. I've tried to make it as simple and logical as possible. This pinout makes great sense if you're buying this [cheap breakout boards](http://www.ebay.com/itm/381547311629) at Ebay or AliExpress (just make sure to remove C3 in order to get auto reset working). The standard LED pin is assigned to Arduino pin 13, and will blink twice if you hit the reset button.
 
 ### ATmega640/1280/2560
 Beside including the original Arduino Mega pinout for the ATmega640/1280/2560, I've also added an *AVR style pinout*, which is a more straight forward and logical pinout if you're not working with the Arduino Mega board. For the default Arduino Mega pinout, the standard LED pin is assigned to Arduino pin 13, and for the AVR pin it's assigned to pin 22.

--- a/avr/libraries/SPI/src/SPI.h
+++ b/avr/libraries/SPI/src/SPI.h
@@ -109,7 +109,7 @@ private:
     // slowest (128 == 2 ^^ 7, so clock_div = 6).
     uint8_t clockDiv;
 
-    // When the clock is known at compiletime, use this if-then-else
+    // When the clock is known at compile time, use this if-then-else
     // cascade, which the compiler knows how to completely optimize
     // away. When clock is not known, use a loop instead, which generates
     // shorter code.

--- a/avr/travis-ci/etc/codespell-ignore-words-list.txt
+++ b/avr/travis-ci/etc/codespell-ignore-words-list.txt
@@ -1,3 +1,4 @@
 hart
 aci
 nd
+inport


### PR DESCRIPTION
Previously, the full range of usable IDE versions was tested for backwards compatibility during the Travis CI build. Attempting to test the full range of IDE versions caused the job length to exceed Travis CI's maximum allowed job duration. For this reason, the IDE version range was split in two, and a job created for each half of the range. This resulted in a significant increase in the number of jobs in the CI build. With the addition of the AT90CAN boards, the job count exceeded Travis CI's maximum of 200. The solution was to restrict backwards compatibility testing to significant IDE versions, which should still provide reasonable backwards compatibility testing coverage while keeping the job count under the maximum (with room to grow) and reduce the build duration.

- Fix misspelled words which caused the spell check to fail.