### PR TITLE
Change some CI build errors to warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,11 @@ env:
 
 
 matrix:
+  allow_failures:
+    # define the key used to determine whether job failures are allowed
+    - env: ALLOW_FAILURES=true
   include:
-    - env: NAME=Formatting Checks
+    - name: 'Formatting Checks'
       # Must define an empty before_install phase, otherwise the shared one is used
       before_install: true
       script:
@@ -27,11 +30,11 @@ matrix:
         # Check for tabs
         - find . -path './.git' -prune -or -path './avr/travis-ci' -prune -or -path './avr/cores/MCUdude_corefiles' -prune -or -path './avr/bootloaders' -prune -or \( -not -name 'keywords.txt' -and -type f \) -exec grep --with-filename --line-number --binary-files=without-match --regexp=$'\t' '{}' \; -exec echo 'Tab found.' \; -exec false '{}' +
         # Check for trailing whitespace
-        - find . -path './.git' -prune -or -path './avr/travis-ci' -prune -or -path './avr/cores/MCUdude_corefiles' -prune -or -path './avr/bootloaders' -prune -or -type f -exec grep --with-filename --line-number --binary-files=without-match --regexp='[[:blank:]]$' '{}' \; -exec echo 'Trailing whitespace found.' \; -exec false '{}' +
+        - find . -path './.git' -prune -or -path './avr/travis-ci' -prune -or -path './avr/cores/MCUdude_corefiles' -prune -or -path './avr/bootloaders' -prune -or -type f -exec grep --with-filename --line-number --binary-files=without-match --regexp='[[:blank:]]$' '{}' \; -exec echo 'Trailing whitespace found.' '{}' +
         # Check for non-Unix line endings
         - find . -path './.git' -prune -or -path './avr/travis-ci' -prune -or -path './avr/cores/MCUdude_corefiles' -prune -or -path './avr/bootloaders' -prune -or -type f -exec grep --files-with-matches --binary-files=without-match --regexp=$'\r$' '{}' \; -exec echo 'Non-Unix EOL detected.' \; -exec false '{}' +
         # Check for blank lines at end of files
-        - find . -path './.git' -prune -or -path './avr/travis-ci' -prune -or -path './avr/cores/MCUdude_corefiles' -prune -or -path './avr/bootloaders' -prune -or -type f -print0 | xargs -0 -L1 bash -c 'tail -1 "$0" | grep --binary-files=without-match --regexp="^$"; if [[ "$?" == "0" ]]; then echo "Blank line found at end of $0."; false; fi'
+        - find . -path './.git' -prune -or -path './avr/travis-ci' -prune -or -path './avr/cores/MCUdude_corefiles' -prune -or -path './avr/bootloaders' -prune -or -type f -print0 | xargs -0 -L1 bash -c 'tail -1 "$0" | grep --binary-files=without-match --regexp="^$"; if [[ "$?" == "0" ]]; then echo "Blank line found at end of $0."; fi'
         # Check for files that don't end in a newline (https://stackoverflow.com/a/25686825)
         - find . -path './.git' -prune -or -path './avr/travis-ci' -prune -or -path './avr/cores/MCUdude_corefiles' -prune -or -path './avr/bootloaders' -prune -or -type f -print0 | xargs -0 -L1 bash -c 'if test "$(grep --files-with-matches --binary-files=without-match --max-count=1 --regexp='.*' "$0")" && test "$(tail --bytes=1 "$0")"; then echo "No new line at end of $0."; false; fi'
       # Must define an empty after_script phase, otherwise the shared one is used
@@ -39,7 +42,8 @@ matrix:
 
 
     # https://github.com/codespell-project/codespell
-    - env: NAME=Spell Check
+    - name: 'Spell Check'
+      env: ALLOW_FAILURES=true
       language: python
       python: 3.6
       before_install:
@@ -50,7 +54,7 @@ matrix:
       after_script:
 
     # https://github.com/per1234/arduino-ci-script
-    - env: NAME=arduino-ci-script Extra Checks
+    - name: 'arduino-ci-script Extra Checks'
       before_install:
         # Install arduino-ci-script
         - source "${TRAVIS_BUILD_DIR}/avr/travis-ci/arduino-ci-script/arduino-ci-script.sh"


### PR DESCRIPTION
The following issues will no longer cause Travis CI builds to fail:
- Trailing whitespace
- Extra blank lines at the end of files
- Spell check

Fixes https://github.com/MCUdude/MegaCore/issues/112