### PR TITLE
Use correct prefix on ATmega2561 fuse definitions

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -59,7 +59,7 @@ menu.bootloader=Bootloader
 2561.menu.bootloader.uart0.upload.protocol=arduino
 2561.menu.bootloader.uart0.upload.port=UART0
 2561.menu.bootloader.uart0.build.export_merged_output=true
-2561.menu.bootloader.uart0.bootloader.high_fuses=b1101{bootloader.eesave_bit}110
+2561.menu.bootloader.uart0.bootloader.high_fuses=0b1101{bootloader.eesave_bit}110
 2561.menu.bootloader.uart0.bootloader.file=optiboot_flash/bootloaders/{build.mcu}/{build.clock_speed}/optiboot_flash_{build.mcu}_{upload.port}_{upload.speed}_{build.clock_speed}_{build.bootloader_led}_BIGBOOT.hex
 
 2561.menu.bootloader.uart1=Yes (UART1)
@@ -67,13 +67,13 @@ menu.bootloader=Bootloader
 2561.menu.bootloader.uart1.upload.protocol=arduino
 2561.menu.bootloader.uart1.upload.port=UART1
 2561.menu.bootloader.uart1.build.export_merged_output=true
-2561.menu.bootloader.uart1.bootloader.high_fuses=b1101{bootloader.eesave_bit}110
+2561.menu.bootloader.uart1.bootloader.high_fuses=0b1101{bootloader.eesave_bit}110
 2561.menu.bootloader.uart1.bootloader.file=optiboot_flash/bootloaders/{build.mcu}/{build.clock_speed}/optiboot_flash_{build.mcu}_{upload.port}_{upload.speed}_{build.clock_speed}_{build.bootloader_led}_BIGBOOT.hex
 
 2561.menu.bootloader.no_bootloader=No bootloader
 2561.menu.bootloader.no_bootloader.upload.maximum_size=262144
 2561.menu.bootloader.no_bootloader.build.export_merged_output=false
-2561.menu.bootloader.no_bootloader.bootloader.high_fuses=b1101{bootloader.eesave_bit}111
+2561.menu.bootloader.no_bootloader.bootloader.high_fuses=0b1101{bootloader.eesave_bit}111
 2561.menu.bootloader.no_bootloader.bootloader.file=empty/empty.hex
 
 # EEPROM


### PR DESCRIPTION
The "0" in the "0b" binary literal prefix was missing from the ATmega2561 fuse values.

Credit to Arduino forum member smp4616:
https://forum.arduino.cc/index.php?topic=726796